### PR TITLE
do not show preview for chirpychat. this eliminates a bug where Turbo…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 
 gem 'jquery-rails'
 gem 'jbuilder'
-gem 'turbolinks', '~> 5.0.0'
+gem 'turbolinks', '~> 5.0.1'
 
 group :development, :test, :demo do
   gem 'factory_girl_rails', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,7 +414,7 @@ GEM
     timecop (0.8.1)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
-    turbolinks-source (5.0.0)
+    turbolinks-source (5.0.2)
     twilio-ruby (4.11.1)
       builder (>= 2.1.2)
       jwt (~> 1.0)
@@ -505,7 +505,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   timecop (~> 0.8.1)
-  turbolinks (~> 5.0.0)
+  turbolinks (~> 5.0.1)
   twilio-ruby (~> 4.11.0)
   uglifier (>= 1.3.0)
   vcr (~> 3.0.0)

--- a/app/views/layouts/messages.html.slim
+++ b/app/views/layouts/messages.html.slim
@@ -2,6 +2,7 @@ doctype html
 html
   head
     = render partial: "layouts/head"
+    meta name='turbolinks-cache-control' content='no-preview'
   body class==(content_for?(:body_class) ? content_for(:body_class) : 'chat')
     = render "components/navigation"
     .messages


### PR DESCRIPTION
…links.ScrollManager and messages.js scroll handling were seomtimes not playing nice together causing the chirpychat header panel to be partially hidden