### PR TITLE
Add call to configure sentry user context.

### DIFF
--- a/lib/reminder/alert.rb
+++ b/lib/reminder/alert.rb
@@ -15,6 +15,15 @@ class Reminder::Alert
   end
 
   def message
+    # setting this raven user context should provide some assistance with
+    # tracking down users that have invalid phone numbers and we are
+    # crashing while trying to send a reminder.
+    Raven.user_context(
+      # a unique ID which represents this user
+      id: contact.id, # 1
+      # name, if available
+      username: contact.name
+    )
     @message ||= begin
       organization.message(
         recipient: contact.person,


### PR DESCRIPTION
@knmurphy I think this may help with tracking down the crashing reminder jobs.

Things I don't know the answer to:
* how do we know this code will work instead of crashing *all the alert jobs* because the raven gem isn't loaded?
* does it work?