### PR TITLE
remove rollbar and lead dyno integrations from html

### DIFF
--- a/app/views/layouts/_head.html.slim
+++ b/app/views/layouts/_head.html.slim
@@ -8,9 +8,7 @@
 - else
   javascript:
     dataLayer = [{}];
-= render "layouts/rollbar/script"
 = render "layouts/google_tag_manager/script"
-= render "layouts/leaddyno/script" if Rails.env.production?
 meta content="IE=edge" http-equiv="X-UA-Compatible"
 meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport"
 meta content=("text/html; charset=UTF-8") http-equiv="Content-Type" /


### PR DESCRIPTION
this should remove the dozen or so javascript errors that
are happening in the developer console when people visit the login
page.