### PR TITLE
Fix tags in select2 autocomplete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,9 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-lodash', '~> 4.17.11'
   gem 'rails-assets-popper.js', '~> 1.15.0'
   gem 'rails-assets-ramda', '~> 0.26.0'
-  gem 'rails-assets-select2', '~> 4.0.7'
+  # don't use 4.0.6 or 4.0.7 due to tags focus bug
+  # https://github.com/select2/select2/pull/5558
+  # https://kindlyops.atlassian.net/browse/CH-83
+  gem 'rails-assets-select2', '4.0.5'
   gem 'rails-assets-timepicker', '~> 1.11.15'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1065,7 +1065,7 @@ GEM
     rails-assets-lodash (4.17.11)
     rails-assets-popper.js (1.15.0)
     rails-assets-ramda (0.26.0)
-    rails-assets-select2 (4.0.7)
+    rails-assets-select2 (4.0.5)
     rails-assets-timepicker (1.11.15)
       rails-assets-jquery (>= 1.7)
     rails-controller-testing (1.0.1)
@@ -1315,7 +1315,7 @@ DEPENDENCIES
   rails-assets-lodash (~> 4.17.11)!
   rails-assets-popper.js (~> 1.15.0)!
   rails-assets-ramda (~> 0.26.0)!
-  rails-assets-select2 (~> 4.0.7)!
+  rails-assets-select2 (= 4.0.5)!
   rails-assets-timepicker (~> 1.11.15)!
   rails-controller-testing
   rails_12factor (~> 0.0.3)


### PR DESCRIPTION
Fixes CH-83 where tag autocomplete was losing focus after 2 characters.

See https://github.com/select2/select2/issues/5485